### PR TITLE
Переключение версии SDK на 19.710 в ветке rc-19.710

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ import java.time.*
 import java.lang.Math
 
 node ('controls') {
-def version = "19.700"
+def version = "19.710"
 def workspace = "/home/sbis/workspace/router_${version}/${BRANCH_NAME}"
     ws (workspace){
         deleteDir()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "Router",
-   "version": "19.700.0",
+   "version": "19.710.0",
    "repository": {
       "type": "git",
       "url": "git@platform-git.sbis.ru:saby/router.git"
@@ -54,16 +54,16 @@
       "eslint": "^5.6.1",
       "express": "^4.16.3",
       "requirejs": "2.1.18",
-      "rmi": "git+https://git.sbis.ru/sbis/rmi.git#rc-19.700",
-      "sbis3-builder": "git+https://github.com/saby/Builder.git#rc-19.700",
-      "saby-i18n": "git+https://github.com/saby/i18n.git#rc-19.700",
-      "sbis3-ws": "git+https://git.sbis.ru/sbis/ws.git#rc-19.700",
-      "saby-ui": "git+https://github.com/saby/UI.git#rc-19.700",
+      "rmi": "git+https://git.sbis.ru/sbis/rmi.git#rc-19.710",
+      "sbis3-builder": "git+https://github.com/saby/Builder.git#rc-19.710",
+      "saby-i18n": "git+https://github.com/saby/i18n.git#rc-19.710",
+      "sbis3-ws": "git+https://git.sbis.ru/sbis/ws.git#rc-19.710",
+      "saby-ui": "git+https://github.com/saby/UI.git#rc-19.710",
       "serve-static": "1.13.x",
-      "saby-types": "git+https://github.com/saby/Types.git#rc-19.700",
-      "saby-typescript": "git+https://github.com/saby/TypeScript.git#rc-19.700",
-      "saby-units": "git+https://github.com/saby/Units.git#rc-19.700",
-      "sbis-cdn": "git+https://github.com/saby/wasaby-cdn.git#rc-19.700",
-      "wasaby-app": "git+https://github.com/saby/wasaby-app.git#rc-19.700"
+      "saby-types": "git+https://github.com/saby/Types.git#rc-19.710",
+      "saby-typescript": "git+https://github.com/saby/TypeScript.git#rc-19.710",
+      "saby-units": "git+https://github.com/saby/Units.git#rc-19.710",
+      "sbis-cdn": "git+https://github.com/saby/wasaby-cdn.git#rc-19.710",
+      "wasaby-app": "git+https://github.com/saby/wasaby-app.git#rc-19.710"
    }
 }


### PR DESCRIPTION
Мерж создан сборкой "http://ci.sbis.ru/job/sdk_cheker/5352/".