### PR TITLE
Переключение версии SDK на 20.3200 в ветке rc-20.3200

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 @Library('pipeline') _
 
-def version = '20.3100'
+def version = '20.3200'
 
 node ('controls') {
     checkout_pipeline("rc-${version}")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "Router",
-   "version": "20.3100.0",
+   "version": "20.3200.0",
    "repository": {
       "type": "git",
       "url": "git@platform-git.sbis.ru:saby/router.git"
@@ -55,16 +55,16 @@
       "eslint": "^5.6.1",
       "express": "^4.16.3",
       "requirejs": "2.1.18",
-      "rmi": "git+https://git.sbis.ru/sbis/rmi.git#rc-20.3100",
-      "sbis3-builder": "git+https://platform-git.sbis.ru/saby/Builder.git#rc-20.3100",
-      "saby-i18n": "git+https://platform-git.sbis.ru/saby/i18n.git#rc-20.3100",
-      "sbis3-ws": "git+https://git.sbis.ru/sbis/ws.git#rc-20.3100",
-      "saby-ui": "git+https://platform-git.sbis.ru/saby/UI.git#rc-20.3100",
+      "rmi": "git+https://git.sbis.ru/sbis/rmi.git#rc-20.3200",
+      "sbis3-builder": "git+https://platform-git.sbis.ru/saby/Builder.git#rc-20.3200",
+      "saby-i18n": "git+https://platform-git.sbis.ru/saby/i18n.git#rc-20.3200",
+      "sbis3-ws": "git+https://git.sbis.ru/sbis/ws.git#rc-20.3200",
+      "saby-ui": "git+https://platform-git.sbis.ru/saby/UI.git#rc-20.3200",
       "serve-static": "1.13.x",
-      "saby-types": "git+https://platform-git.sbis.ru/saby/Types.git#rc-20.3100",
-      "saby-typescript": "git+https://platform-git.sbis.ru/saby/TypeScript.git#rc-20.3100",
-      "saby-units": "git+https://platform-git.sbis.ru/saby/Units.git#rc-20.3100",
-      "sbis-cdn": "git+https://platform-git.sbis.ru/saby/wasaby-cdn.git#rc-20.3100",
-      "wasaby-app": "git+https://platform-git.sbis.ru/saby/wasaby-app.git#rc-20.3100"
+      "saby-types": "git+https://platform-git.sbis.ru/saby/Types.git#rc-20.3200",
+      "saby-typescript": "git+https://platform-git.sbis.ru/saby/TypeScript.git#rc-20.3200",
+      "saby-units": "git+https://platform-git.sbis.ru/saby/Units.git#rc-20.3200",
+      "sbis-cdn": "git+https://platform-git.sbis.ru/saby/wasaby-cdn.git#rc-20.3200",
+      "wasaby-app": "git+https://platform-git.sbis.ru/saby/wasaby-app.git#rc-20.3200"
    }
 }


### PR DESCRIPTION
Мерж создан сборкой "http://ci.sbis.ru/job/sdk_cheker/7034/".